### PR TITLE
Lesson5-7: Character Device 

### DIFF
--- a/02-KernelModules_CharacterDevice/Makefile
+++ b/02-KernelModules_CharacterDevice/Makefile
@@ -1,0 +1,11 @@
+modulefile=moduleCharDev
+
+KDIR=$(BUILD_KERNEL)
+
+obj-m := $(modulefile).o
+
+all:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean
+

--- a/02-KernelModules_CharacterDevice/moduleCharDev.c
+++ b/02-KernelModules_CharacterDevice/moduleCharDev.c
@@ -32,7 +32,7 @@ static ssize_t sysfs_show(struct class*, struct class_attribute*, char*);
 static ssize_t sysfs_store(struct class*, struct class_attribute*, const char*, size_t );
 static ssize_t proc_read(struct file*, char __user*, size_t len, loff_t*);
 struct class_attribute sysfs = __ATTR(SYSFS_NAME, 0664, &sysfs_show, &sysfs_store);
-
+module_param(all_memory, int, 0664);
 static int create_buffer(void)
 {
     all_memory += BUFFER_SIZE;
@@ -211,3 +211,4 @@ module_exit(dev_exit);
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Danil Petrov <daaaanil81@gmail.com>");
 MODULE_DESCRIPTION("My First Character Driver");
+MODULE_VERSION("0.1");

--- a/02-KernelModules_CharacterDevice/moduleCharDev.c
+++ b/02-KernelModules_CharacterDevice/moduleCharDev.c
@@ -12,8 +12,8 @@
 #include <linux/slab.h>
 #include <linux/sysfs.h>
 
-#define PROC_FILENAME "MyCharDev"
-#define NAME_SYSCLASS "chardev"
+#define PROC_FILENAME "CharTechnologic"
+#define NAME_SYSCLASS "chartechnologic"
 #define SIZE_STRING 20
 #define BUFFER_SIZE 1024
 #define SYSFS_NAME Cleanup
@@ -57,7 +57,7 @@ static int check_ascii(const char*buf)
     int len = strlen(buf) - 1;
     unsigned int time;
     int i;
-    printk(KERN_INFO "check_ascii: %s and size: %d\n", buf, len);
+    printk(KERN_INFO "Check_ascii: %s and size: %d\n", buf, len);
     for (i = 0; i < len; i++)
     {
         time = buf[i];
@@ -102,34 +102,33 @@ static int dev_close(struct inode *i, struct file *f)
 static ssize_t dev_read(struct file *f, char __user *buf, size_t len, loff_t *off)
 {
     int ret;
-    printk(KERN_INFO "chrdev: read from file %s\n", f->f_path.dentry->d_iname);
+    printk(KERN_INFO "CharTechnologic: read from file %s\n", f->f_path.dentry->d_iname);
     if (len > full_memory) len = full_memory;
     ret = copy_to_user(buf, dev_buffer, len);
     if (ret) {
-        printk(KERN_ERR "chrdev: copy_to_user failed: %d\n", ret);
+        printk(KERN_ERR "CharTechnologic: copy_to_user failed: %d\n", ret);
         return -EFAULT;
     }
     full_memory = 0;
-    printk(KERN_INFO "chrdev: %d bytes read\n", len);
+    printk(KERN_INFO "CharTechnologic: %d bytes read\n", len);
     return len;
 }
-static ssize_t dev_write(
-                         struct file *f, const char __user *buf, size_t len, loff_t *off)
+static ssize_t dev_write(struct file *f, const char __user *buf, size_t len, loff_t *off)
 {
     int ret;
-    printk(KERN_INFO "chrdev: write to file %s\n", f->f_path.dentry->d_iname);
+    printk(KERN_INFO "CharTechnologic: write to file %s\n", f->f_path.dentry->d_iname);
     full_memory = len;
     if (full_memory > all_memory) full_memory = all_memory;
     if (check_ascii(buf) < 0) {
-        printk(KERN_ERR "chrdev: used not allowed characters\n");
+        printk(KERN_ERR "CharTechnologic: used not allowed characters\n");
         return -EFAULT;
     }
     ret = copy_from_user(dev_buffer, buf, full_memory);
     if (ret) {
-        printk(KERN_ERR "chrdev: copy_from_user failed: %d\n", ret);
+        printk(KERN_ERR "CharTechnologic: copy_from_user failed: %d\n", ret);
         return -EFAULT;
     }
-    printk(KERN_INFO "chrdev: %d bytes written\n", full_memory);
+    printk(KERN_INFO "CharTechnologic: %d bytes written\n", full_memory);
     return len;
 }
 static struct file_operations proc_fops =
@@ -158,21 +157,21 @@ static int __init dev_init(void) /* Constructor */
     if(proc_file == NULL) {
         goto fail;
     }
-    printk(KERN_INFO "File /proc/MyCharDev was created\n");
+    printk(KERN_INFO "File /proc/%s was created\n", PROC_FILENAME);
     
     if (IS_ERR(class_device = class_create(THIS_MODULE, NAME_SYSCLASS))) {
         goto fail;
     }
-    printk(KERN_INFO "Class /sys/class/chardev was created\n");
+    printk(KERN_INFO "Class /sys/class/%s was created\n", NAME_SYSCLASS);
     res = class_create_file(class_device, &sysfs);
-    printk(KERN_INFO "File /sys/class/cleanup was created\n");
+    printk(KERN_INFO "File /sys/class/%s/Cleanup was created\n", NAME_SYSCLASS);
     if (res < 0) {
         goto fail;
     }
     if (IS_ERR(dev_ret = device_create(class_device, NULL, first, NULL, NAME_SYSCLASS))) {
         goto fail;
     }
-    printk(KERN_INFO "File /dev/chardev was created\n");
+    printk(KERN_INFO "File /dev/%s was created\n", NAME_SYSCLASS);
     cdev_init(&c_dev, &dev_fops);
     if (cdev_add(&c_dev, first, countFile) < 0){
         goto fail;

--- a/02-KernelModules_CharacterDevice/moduleCharDev.c
+++ b/02-KernelModules_CharacterDevice/moduleCharDev.c
@@ -13,7 +13,7 @@
 
 #define PROC_FILENAME "MyCharDev"
 #define NAME_SYSCLASS "chardev"
-#define SIZE_STRING 10
+#define SIZE_STRING 20
 #define BUFFER_SIZE 1024
 
 static struct proc_dir_entry *proc_file;
@@ -52,7 +52,7 @@ static void cleanup_buffer(void)
 
 static ssize_t proc_read(struct file *f, char __user *buffer, size_t len, loff_t *off)
 {
-    sprintf(size_memory, "%u\n", all_memory);
+    sprintf(size_memory, "%u %u\n", all_memory, all_memory - full_memory);
     len = SIZE_STRING;
     return simple_read_from_buffer(buffer, len, off, size_memory, len);
 }

--- a/02-KernelModules_CharacterDevice/moduleCharDev.c
+++ b/02-KernelModules_CharacterDevice/moduleCharDev.c
@@ -16,7 +16,7 @@
 #define NAME_SYSCLASS "chardev"
 #define SIZE_STRING 20
 #define BUFFER_SIZE 1024
-#define SYSFS_NAME cleanup
+#define SYSFS_NAME Cleanup
 
 static struct proc_dir_entry *proc_file;
 static dev_t first;
@@ -56,11 +56,15 @@ static void cleanup_buffer(void)
 static ssize_t sysfs_show(struct class *class, struct class_attribute *attr, char *buf)
 {
     printk(KERN_INFO "Sysfs_show\n");
+    memset(dev_buffer, 0, all_memory);
+    full_memory = 0;
     return 0;
 }
 static ssize_t sysfs_store(struct class *class, struct class_attribute *attr, const char *buf, size_t count)
 {
     printk(KERN_INFO "Sysfs_store\n");
+    memset(dev_buffer, 0, all_memory);
+    full_memory = 0;
     return count;
 }
 static ssize_t proc_read(struct file *f, char __user *buffer, size_t len, loff_t *off)

--- a/02-KernelModules_CharacterDevice/moduleCharDev.c
+++ b/02-KernelModules_CharacterDevice/moduleCharDev.c
@@ -1,0 +1,30 @@
+#include <linux/module.h>
+#include <linux/version.h>
+#include <linux/proc_fs.h>
+#include <linux/sched.h>
+#include <linux/kernel.h>
+#include <linux/types.h>
+#include <linux/kdev_t.h>
+#include <linux/fs.h>
+#include <linux/device.h>
+#include <linux/cdev.h>
+#include <linux/uaccess.h>
+#include <linux/slab.h>
+
+static int __init dev_init(void) /* Constructor */
+{
+    printk(KERN_INFO "Start device");
+    return 0;
+}
+
+static void __exit dev_exit(void) /* Destructor */
+{
+    printk(KERN_INFO "End device");
+}
+
+module_init(ofcd_init);
+module_exit(ofcd_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Danil Petrov <daaaanil81@gmail.com>");
+MODULE_DESCRIPTION("My First Character Driver");

--- a/02-KernelModules_CharacterDevice/moduleCharDev.c
+++ b/02-KernelModules_CharacterDevice/moduleCharDev.c
@@ -10,26 +10,47 @@
 #include <linux/cdev.h>
 #include <linux/uaccess.h>
 #include <linux/slab.h>
+
 #define PROC_FILENAME "MyModule"
 #define DRIVER_NAME "MyDriver"
 #define SIZE_STRING 10
+
+static struct proc_dir_entry *proc_file;
 static dev_t first;
 static size_t countFile = 1;
+static size_t all_memory = 1024;
+static char size_memory[SIZE_STRING];
+
+static ssize_t proc_read(struct file *f, char __user *buffer, size_t len, loff_t *off)
+{
+    sprintf(size_memory, "%u\n", all_memory);
+    len = SIZE_STRING;
+    return simple_read_from_buffer(buffer, len, off, size_memory, len);
+}
+
+static struct file_operations fops =
+{
+    .read = proc_read,
+};
 
 static int __init dev_init(void) /* Constructor */
 {
     printk(KERN_INFO "Start device");
-    if ((alloc_chrdev_region(&first, 0, countFile, PROC_FILENAME)) < 0)
-    {
+    if ((alloc_chrdev_region(&first, 0, countFile, PROC_FILENAME)) < 0) {
         return -ENOMEM;
     }
     printk(KERN_INFO "Registered: <%d %d>\n", MAJOR(first),MINOR(first));
+    proc_file = proc_create(PROC_FILENAME, S_IFREG | S_IRUGO | S_IWUGO, NULL, &fops);
+    if(proc_file == NULL) {
+        return -ENOMEM;
+    }
     return 0;
 }
 
 static void __exit dev_exit(void) /* Destructor */
 {
     printk(KERN_INFO "End device");
+    remove_proc_entry(PROC_FILENAME, NULL);
     unregister_chrdev_region(first, countFile);
 }
 

--- a/02-KernelModules_CharacterDevice/moduleCharDev.c
+++ b/02-KernelModules_CharacterDevice/moduleCharDev.c
@@ -11,8 +11,8 @@
 #include <linux/uaccess.h>
 #include <linux/slab.h>
 
-#define PROC_FILENAME "MyModule"
-#define DRIVER_NAME "MyDriver"
+#define PROC_FILENAME "MyCharDev"
+#define NAME_SYSCLASS "chardev"
 #define SIZE_STRING 10
 
 static struct proc_dir_entry *proc_file;
@@ -20,6 +20,9 @@ static dev_t first;
 static size_t countFile = 1;
 static size_t all_memory = 1024;
 static char size_memory[SIZE_STRING];
+static struct class *class_device;
+struct device *dev_ret;
+
 
 static ssize_t proc_read(struct file *f, char __user *buffer, size_t len, loff_t *off)
 {
@@ -42,7 +45,21 @@ static int __init dev_init(void) /* Constructor */
     printk(KERN_INFO "Registered: <%d %d>\n", MAJOR(first),MINOR(first));
     proc_file = proc_create(PROC_FILENAME, S_IFREG | S_IRUGO | S_IWUGO, NULL, &fops);
     if(proc_file == NULL) {
+        unregister_chrdev_region(first, countFile);
         return -ENOMEM;
+    }
+    if (IS_ERR(class_device = class_create(THIS_MODULE, NAME_SYSCLASS)))
+    {
+        remove_proc_entry(PROC_FILENAME, NULL);
+        unregister_chrdev_region(first, countFile);
+        return PTR_ERR(class_device);
+    }
+    if (IS_ERR(dev_ret = device_create(class_device, NULL, first, NULL, NAME_SYSCLASS)))
+    {
+        class_destroy(class_device);
+        remove_proc_entry(PROC_FILENAME, NULL);
+        unregister_chrdev_region(first, countFile);
+        return PTR_ERR(dev_ret);
     }
     return 0;
 }
@@ -50,8 +67,12 @@ static int __init dev_init(void) /* Constructor */
 static void __exit dev_exit(void) /* Destructor */
 {
     printk(KERN_INFO "End device");
+    
+    device_destroy(class_device, first);
+    class_destroy(class_device);
     remove_proc_entry(PROC_FILENAME, NULL);
     unregister_chrdev_region(first, countFile);
+    
 }
 
 module_init(dev_init);

--- a/02-KernelModules_CharacterDevice/moduleCharDev.c
+++ b/02-KernelModules_CharacterDevice/moduleCharDev.c
@@ -10,20 +10,31 @@
 #include <linux/cdev.h>
 #include <linux/uaccess.h>
 #include <linux/slab.h>
+#define PROC_FILENAME "MyModule"
+#define DRIVER_NAME "MyDriver"
+#define SIZE_STRING 10
+static dev_t first;
+static size_t countFile = 1;
 
 static int __init dev_init(void) /* Constructor */
 {
     printk(KERN_INFO "Start device");
+    if ((alloc_chrdev_region(&first, 0, countFile, PROC_FILENAME)) < 0)
+    {
+        return -ENOMEM;
+    }
+    printk(KERN_INFO "Registered: <%d %d>\n", MAJOR(first),MINOR(first));
     return 0;
 }
 
 static void __exit dev_exit(void) /* Destructor */
 {
     printk(KERN_INFO "End device");
+    unregister_chrdev_region(first, countFile);
 }
 
-module_init(ofcd_init);
-module_exit(ofcd_exit);
+module_init(dev_init);
+module_exit(dev_exit);
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Danil Petrov <daaaanil81@gmail.com>");

--- a/02-KernelModules_CharacterDevice/moduleCharDev.c
+++ b/02-KernelModules_CharacterDevice/moduleCharDev.c
@@ -36,10 +36,9 @@ module_param(all_memory, int, 0664);
 static int create_buffer(void)
 {
     all_memory += BUFFER_SIZE;
-    dev_buffer = kmalloc(all_memory, GFP_KERNEL);
+    dev_buffer = kzmalloc(all_memory, GFP_KERNEL);
     if (NULL == dev_buffer)
         return -ENOMEM;
-    memset(dev_buffer, 0, all_memory);
     return 0;
 }
 
@@ -47,8 +46,7 @@ static int create_buffer(void)
 static void cleanup_buffer(void)
 {
     if (dev_buffer) {
-        memset(dev_buffer, 0, all_memory);
-        kfree(dev_buffer);
+        kzfree(dev_buffer);
         dev_buffer = NULL;
     }
 }
@@ -62,7 +60,7 @@ static int check_ascii(const char*buf)
     {
         time = buf[i];
         printk(KERN_INFO "%d", time);
-        if (time < 33 || time > 126) {
+        if (time < 32 || time > 126) {
             return -EFAULT;
         }
     }
@@ -98,8 +96,6 @@ static int dev_close(struct inode *i, struct file *f)
 {
     printk(KERN_INFO "Driver: close()\n");
     return 0;
-}
-static ssize_t dev_read(struct file *f, char __user *buf, size_t len, loff_t *off)
 {
     int ret;
     printk(KERN_INFO "CharTechnologic: read from file %s\n", f->f_path.dentry->d_iname);


### PR DESCRIPTION
Implement a character device driver for text messaging between users.

1. Implement a character device driver with the following requirements:
- 1kB buffer size;
- buffer increase as a module parameter ;
- should be available for all users;
- works only ASCII strings.

2.  Add the interfaces into the driver:
- sysfs for buffer clean up;
- procfs for displaying used buffer volume and buffer size

Bash script will be later. 
@galkinletter Check please my task.