### PR TITLE
MPU6050 practice: Implement bash script and kernel module modification

### DIFF
--- a/02-KernelModules_CharacterDevice/README.md
+++ b/02-KernelModules_CharacterDevice/README.md
@@ -1,3 +1,21 @@
-# Kernel Modules, Character Devices
+# Lesson 5-7 (Kernel Modules, Character Devices)
 
+## The deadline is April 12 for all Parts
 
+# Task - Implement a character device driver for text messaging between users.
+
+#Part 1. Implement a character device driver with the following requirements:
+- 1kB buffer size;
+- buffer increase as a module parameter ;
+- should be available for all users;
+- works only ASCII strings.
+
+#Part 2.  Add the interfaces into the driver:
+- sysfs for buffer clean up;
+- procfs for displaying used buffer volume and buffer size
+
+#Part 3. Implement shell/bash script for the driver testing. 
+
+#Part 4. Provide a test scenario.
+
+Implemented character device should be committed to GitHub. During implementation, please follow to code and git style. 

--- a/04-mpu6050/README.md
+++ b/04-mpu6050/README.md
@@ -1,3 +1,5 @@
-# MPU6050 Practice. Kernel object module development
+# MPU6050 Practice.
 
-## Homework
+This practice is splitted on 2 parts:
+    scripts - user space tools with driver i2c-dev
+    module - kernel module development

--- a/04-mpu6050/module/README.md
+++ b/04-mpu6050/module/README.md
@@ -1,0 +1,12 @@
+# MPU6050 Practice. Kernel module
+
+## Homework
+
+1. Build Linux kernel from www.kernel.org for Orange PI
+	Use build instruction from http://linux-sunxi.org/Mainline_Kernel_Howto
+	make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- sunxi_defconfig
+	ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- make -j4 zImage
+2. Build driver for mpu6050 which provide data to sysfs
+3. Measure temperature in F. with precision 0.001 F
+4. (Optional) create digital filter for temperature channel.
+  E.g. moving averange filter for 1000 points.

--- a/04-mpu6050/scripts/README.md
+++ b/04-mpu6050/scripts/README.md
@@ -1,0 +1,15 @@
+# MPU6050 Practice. Hardware diagnostic and user space mode
+
+## Homework
+
+1. Download datasheet and registers map for mpu6050(mpu6000). Use it as reference.
+2. Connect gyroscope, accelerometer, thermometer to OrangePI using schematic for Orange PI One 
+	and schematic for board GY-521.
+3. Check connected hardware using tools for communication from Linux user space i2c-tools package.
+	Tools i2detect, i2cdump, i2cset, i2cget
+4. Check the value WHO_AM_I register in mpu6050.
+5. Run mpu6050 by setting DEVICE_RESET bit of PWR_MGMT_1 to 0.
+6. Print value of temperature (TEMP_OUT_H, TEMP_OUT_L) using i2cget.
+7. (Optional) Write shell script which prints value of temperature (TEMP_OUT_H, TEMP_OUT_L)
+	once per second using i2cget in infinite loop. Value should be converted to F and C.
+	Upload the script into repository to folder ‘mpu6050_scripts’.

--- a/mpu6050/Makefile
+++ b/mpu6050/Makefile
@@ -1,0 +1,32 @@
+#
+# mpu6050 accelerometer & gyroscope
+#
+ifneq ($(KERNELRELEASE),)
+
+obj-m := mpu6050.o
+
+else
+
+
+ifeq ($(KERNELDIR),)
+ifeq ($(BBB_KERNEL),)
+	$(error Path to kernel tree - KERNELDIR or BBB_KERNEL variable is not defined!)
+endif
+endif
+
+KERNELDIR ?= $(BBB_KERNEL)
+
+export ARCH = arm
+export CROSS_COMPILE ?= arm-linux-gnueabihf-
+
+
+.PHONY: all clean
+
+all:
+	$(MAKE) -C $(KERNELDIR) M=$(CURDIR) modules
+
+clean:
+	$(MAKE) -C $(KERNELDIR) M=$(CURDIR) clean
+
+
+endif

--- a/mpu6050/README.md
+++ b/mpu6050/README.md
@@ -1,0 +1,11 @@
+# MPU6050 Practice. Kernel object module development
+
+## Homework
+
+1. Create simplest driver (kernel object module) using compiled kernel (by Armbian or without it)  
+	and cross-compiler.
+2. Fix errors in driver mpu6050 from repository.
+3. Сompile it using cross-compiler.
+4. Deploy and run it. Check output using dmesg.
+5. Check modified DTS.
+6. Check driver’s output by reading value from sysfs

--- a/mpu6050/mpu6050-regs.h
+++ b/mpu6050/mpu6050-regs.h
@@ -1,0 +1,33 @@
+#ifndef _MPU6050_REGS_H
+#define _MPU6050_REGS_H
+
+/* Registed addresses */
+#define REG_CONFIG			0x1A
+#define REG_GYRO_CONFIG		0x1B
+#define REG_ACCEL_CONFIG	0x1C
+#define REG_FIFO_EN			0x23
+#define REG_INT_PIN_CFG		0x37
+#define REG_INT_ENABLE		0x38
+#define REG_ACCEL_XOUT_H	0x3B
+#define REG_ACCEL_XOUT_L	0x3C
+#define REG_ACCEL_YOUT_H	0x3D
+#define REG_ACCEL_YOUT_L	0x3E
+#define REG_ACCEL_ZOUT_H	0x3F
+#define REG_ACCEL_ZOUT_L	0x40
+#define REG_TEMP_OUT_H		0x41
+#define REG_TEMP_OUT_L		0x42
+#define REG_GYRO_XOUT_H		0x43
+#define REG_GYRO_XOUT_L		0x44
+#define REG_GYRO_YOUT_H		0x45
+#define REG_GYRO_YOUT_L		0x46
+#define REG_GYRO_ZOUT_H		0x47
+#define REG_GYRO_ZOUT_L		0x48
+#define REG_USER_CTRL		0x6A
+#define REG_PWR_MGMT_1		0x6B
+#define REG_PWR_MGMT_2		0x6C
+#define REG_WHO_AM_I		0x75
+
+/* Register values */
+#define MPU6050_WHO_AM_I	0x68
+
+#endif /* _MPU6050_REGS_H */

--- a/mpu6050/mpu6050.c
+++ b/mpu6050/mpu6050.c
@@ -5,11 +5,34 @@
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 
+#include "mpu6050-regs.h"
+
 static int mpu6050_probe(struct i2c_client *drv_client,
 			 const struct i2c_device_id *id)
 {
+	int ret;
+
 	dev_info(&drv_client->dev,
 		"i2c client address is 0x%X\n", drv_client->addr);
+
+	/* Read who_am_i register */
+	ret = i2c_smbus_read_byte_data(drv_client, REG_WHO_AM_I);
+	if (IS_ERR_VALUE(ret)) {
+		dev_err(&drv_client->dev,
+			"i2c_smbus_read_byte_data() failed with error: %d\n",
+			ret);
+		return ret;
+	}
+	if (ret != MPU6050_WHO_AM_I) {
+		dev_err(&drv_client->dev,
+			"wrong i2c device found: expected 0x%X, found 0x%X\n",
+			MPU6050_WHO_AM_I, ret);
+		return -1;
+	}
+	dev_info(&drv_client->dev,
+		"i2c mpu6050 device found, WHO_AM_I register value = 0x%X\n",
+		ret);
+
 	dev_info(&drv_client->dev, "i2c driver probed\n");
 	return 0;
 }

--- a/mpu6050/mpu6050.c
+++ b/mpu6050/mpu6050.c
@@ -1,0 +1,23 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/device.h>
+#include <linux/err.h>
+
+static int mpu6050_init(void)
+{
+	pr_info("mpu6050: module loaded\n");
+	return 0;
+}
+
+static void mpu6050_exit(void)
+{
+	pr_info("mpu6050: module exited\n");
+}
+
+module_init(mpu6050_init);
+module_exit(mpu6050_exit);
+
+MODULE_AUTHOR("Andriy.Khulap <andriy.khulap@globallogic.com>");
+MODULE_DESCRIPTION("mpu6050 I2C acc&gyro");
+MODULE_LICENSE("GPL");
+MODULE_VERSION("0.1");

--- a/mpu6050/mpu6050.c
+++ b/mpu6050/mpu6050.c
@@ -7,6 +7,53 @@
 
 #include "mpu6050-regs.h"
 
+
+struct mpu6050_data {
+	struct i2c_client *drv_client;
+	int accel_values[3];
+	int gyro_values[3];
+	int temperature;
+};
+
+static struct mpu6050_data g_mpu6050_data;
+
+static int mpu6050_read_data(void)
+{
+	int temp;
+	struct i2c_client *drv_client = g_mpu6050_data.drv_client;
+
+	if (drv_client == 0)
+		return -ENODEV;
+
+	/* accel */
+	g_mpu6050_data.accel_values[0] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_ACCEL_XOUT_H));
+	g_mpu6050_data.accel_values[1] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_ACCEL_YOUT_H));
+	g_mpu6050_data.accel_values[2] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_ACCEL_ZOUT_H));
+	/* gyro */
+	g_mpu6050_data.gyro_values[0] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_GYRO_XOUT_H));
+	g_mpu6050_data.gyro_values[1] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_GYRO_YOUT_H));
+	g_mpu6050_data.gyro_values[2] = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_GYRO_ZOUT_H));
+	/* Temperature in degrees C =
+	 * (TEMP_OUT Register Value  as a signed quantity)/340 + 36.53
+	 */
+	temp = (s16)((u16)i2c_smbus_read_word_swapped(drv_client, REG_TEMP_OUT_H));
+	g_mpu6050_data.temperature = (temp + 12420 + 170) / 340;
+
+	dev_info(&drv_client->dev, "sensor data read:\n");
+	dev_info(&drv_client->dev, "ACCEL[X,Y,Z] = [%d, %d, %d]\n",
+		g_mpu6050_data.accel_values[0],
+		g_mpu6050_data.accel_values[1],
+		g_mpu6050_data.accel_values[2]);
+	dev_info(&drv_client->dev, "GYRO[X,Y,Z] = [%d, %d, %d]\n",
+		g_mpu6050_data.gyro_values[0],
+		g_mpu6050_data.gyro_values[1],
+		g_mpu6050_data.gyro_values[2]);
+	dev_info(&drv_client->dev, "TEMP = %d\n",
+		g_mpu6050_data.temperature);
+
+	return 0;
+}
+
 static int mpu6050_probe(struct i2c_client *drv_client,
 			 const struct i2c_device_id *id)
 {
@@ -33,12 +80,28 @@ static int mpu6050_probe(struct i2c_client *drv_client,
 		"i2c mpu6050 device found, WHO_AM_I register value = 0x%X\n",
 		ret);
 
+	/* Setup the device */
+	/* No error handling here! */
+	i2c_smbus_write_byte_data(drv_client, REG_CONFIG, 0);
+	i2c_smbus_write_byte_data(drv_client, REG_GYRO_CONFIG, 0);
+	i2c_smbus_write_byte_data(drv_client, REG_ACCEL_CONFIG, 0);
+	i2c_smbus_write_byte_data(drv_client, REG_FIFO_EN, 0);
+	i2c_smbus_write_byte_data(drv_client, REG_INT_PIN_CFG, 0);
+	i2c_smbus_write_byte_data(drv_client, REG_INT_ENABLE, 0);
+	i2c_smbus_write_byte_data(drv_client, REG_USER_CTRL, 0);
+	i2c_smbus_write_byte_data(drv_client, REG_PWR_MGMT_1, 0);
+	i2c_smbus_write_byte_data(drv_client, REG_PWR_MGMT_2, 0);
+
+	g_mpu6050_data.drv_client = drv_client;
+
 	dev_info(&drv_client->dev, "i2c driver probed\n");
 	return 0;
 }
 
 static int mpu6050_remove(struct i2c_client *drv_client)
 {
+	g_mpu6050_data.drv_client = 0;
+
 	dev_info(&drv_client->dev, "i2c driver removed\n");
 	return 0;
 }
@@ -59,6 +122,79 @@ static struct i2c_driver mpu6050_i2c_driver = {
 	.id_table = mpu6050_idtable,
 };
 
+static ssize_t accel_x_show(struct class *class,
+			    struct class_attribute *attr, char *buf)
+{
+	mpu6050_read_data();
+
+	sprintf(buf, "%d\n", g_mpu6050_data.accel_values[0]);
+	return strlen(buf);
+}
+
+static ssize_t accel_y_show(struct class *class,
+			    struct class_attribute *attr, char *buf)
+{
+	mpu6050_read_data();
+
+	sprintf(buf, "%d\n", g_mpu6050_data.accel_values[1]);
+	return strlen(buf);
+}
+
+static ssize_t accel_z_show(struct class *class,
+			    struct class_attribute *attr, char *buf)
+{
+	mpu6050_read_data();
+
+	sprintf(buf, "%d\n", g_mpu6050_data.accel_values[2]);
+	return strlen(buf);
+}
+
+static ssize_t gyro_x_show(struct class *class,
+			   struct class_attribute *attr, char *buf)
+{
+	mpu6050_read_data();
+
+	sprintf(buf, "%d\n", g_mpu6050_data.gyro_values[0]);
+	return strlen(buf);
+}
+
+static ssize_t gyro_y_show(struct class *class,
+			   struct class_attribute *attr, char *buf)
+{
+	mpu6050_read_data();
+
+	sprintf(buf, "%d\n", g_mpu6050_data.gyro_values[1]);
+	return strlen(buf);
+}
+
+static ssize_t gyro_z_show(struct class *class,
+			   struct class_attribute *attr, char *buf)
+{
+	mpu6050_read_data();
+
+	sprintf(buf, "%d\n", g_mpu6050_data.gyro_values[2]);
+	return strlen(buf);
+}
+
+static ssize_t temp_show(struct class *class,
+			 struct class_attribute *attr, char *buf)
+{
+	mpu6050_read_data();
+
+	sprintf(buf, "%d\n", g_mpu6050_data.temperature);
+	return strlen(buf);
+}
+
+CLASS_ATTR(accel_x, 0444, &accel_x_show, NULL);
+CLASS_ATTR(accel_y, 0444, &accel_y_show, NULL);
+CLASS_ATTR(accel_z, 0444, &accel_z_show, NULL);
+CLASS_ATTR(gyro_x, 0444, &gyro_x_show, NULL);
+CLASS_ATTR(gyro_y, 0444, &gyro_y_show, NULL);
+CLASS_ATTR(gyro_z, 0444, &gyro_z_show, NULL);
+CLASS_ATTR(temperature, 0444, &temp_show, NULL);
+
+static struct class *attr_class;
+
 static int mpu6050_init(void)
 {
 	int ret;
@@ -71,12 +207,80 @@ static int mpu6050_init(void)
 	}
 	pr_info("mpu6050: i2c driver created\n");
 
+	/* Create class */
+	attr_class = class_create(THIS_MODULE, "mpu6050");
+	if (IS_ERR(attr_class)) {
+		ret = PTR_ERR(attr_class);
+		pr_err("mpu6050: failed to create sysfs class: %d\n", ret);
+		return ret;
+	}
+	pr_info("mpu6050: sysfs class created\n");
+
+	/* Create accel_x */
+	ret = class_create_file(attr_class, &class_attr_accel_x);
+	if (ret) {
+		pr_err("mpu6050: failed to create sysfs class attribute accel_x: %d\n", ret);
+		return ret;
+	}
+	/* Create accel_y */
+	ret = class_create_file(attr_class, &class_attr_accel_y);
+	if (ret) {
+		pr_err("mpu6050: failed to create sysfs class attribute accel_y: %d\n", ret);
+		return ret;
+	}
+	/* Create accel_z */
+	ret = class_create_file(attr_class, &class_attr_accel_z);
+	if (ret) {
+		pr_err("mpu6050: failed to create sysfs class attribute accel_z: %d\n", ret);
+		return ret;
+	}
+	/* Create gyro_x */
+	ret = class_create_file(attr_class, &class_attr_gyro_x);
+	if (ret) {
+		pr_err("mpu6050: failed to create sysfs class attribute gyro_x: %d\n", ret);
+		return ret;
+	}
+	/* Create gyro_y */
+	ret = class_create_file(attr_class, &class_attr_gyro_y);
+	if (ret) {
+		pr_err("mpu6050: failed to create sysfs class attribute gyro_y: %d\n", ret);
+		return ret;
+	}
+	/* Create gyro_z */
+	ret = class_create_file(attr_class, &class_attr_gyro_z);
+	if (ret) {
+		pr_err("mpu6050: failed to create sysfs class attribute gyro_z: %d\n", ret);
+		return ret;
+	}
+	/* Create temperature */
+	ret = class_create_file(attr_class, &class_attr_temperature);
+	if (ret) {
+		pr_err("mpu6050: failed to create sysfs class attribute temperature: %d\n", ret);
+		return ret;
+	}
+
+	pr_info("mpu6050: sysfs class attributes created\n");
+
 	pr_info("mpu6050: module loaded\n");
 	return 0;
 }
 
 static void mpu6050_exit(void)
 {
+	if (attr_class) {
+		class_remove_file(attr_class, &class_attr_accel_x);
+		class_remove_file(attr_class, &class_attr_accel_y);
+		class_remove_file(attr_class, &class_attr_accel_z);
+		class_remove_file(attr_class, &class_attr_gyro_x);
+		class_remove_file(attr_class, &class_attr_gyro_y);
+		class_remove_file(attr_class, &class_attr_gyro_z);
+		class_remove_file(attr_class, &class_attr_temperature);
+		pr_info("mpu6050: sysfs class attributes removed\n");
+
+		class_destroy(attr_class);
+		pr_info("mpu6050: sysfs class destroyed\n");
+	}
+
 	i2c_del_driver(&mpu6050_i2c_driver);
 	pr_info("mpu6050: i2c driver deleted\n");
 

--- a/mpu6050/mpu6050.c
+++ b/mpu6050/mpu6050.c
@@ -2,15 +2,61 @@
 #include <linux/module.h>
 #include <linux/device.h>
 #include <linux/err.h>
+#include <linux/i2c.h>
+#include <linux/i2c-dev.h>
+
+static int mpu6050_probe(struct i2c_client *drv_client,
+			 const struct i2c_device_id *id)
+{
+	dev_info(&drv_client->dev,
+		"i2c client address is 0x%X\n", drv_client->addr);
+	dev_info(&drv_client->dev, "i2c driver probed\n");
+	return 0;
+}
+
+static int mpu6050_remove(struct i2c_client *drv_client)
+{
+	dev_info(&drv_client->dev, "i2c driver removed\n");
+	return 0;
+}
+
+static const struct i2c_device_id mpu6050_idtable[] = {
+	{ "mpu6050", 0 },
+	{ }
+};
+MODULE_DEVICE_TABLE(i2c, mpu6050_idtable);
+
+static struct i2c_driver mpu6050_i2c_driver = {
+	.driver = {
+		.name = "gl_mpu6050",
+	},
+
+	.probe = mpu6050_probe,
+	.remove = mpu6050_remove,
+	.id_table = mpu6050_idtable,
+};
 
 static int mpu6050_init(void)
 {
+	int ret;
+
+	/* Create i2c driver */
+	ret = i2c_add_driver(&mpu6050_i2c_driver);
+	if (ret) {
+		pr_err("mpu6050: failed to add new i2c driver: %d\n", ret);
+		return ret;
+	}
+	pr_info("mpu6050: i2c driver created\n");
+
 	pr_info("mpu6050: module loaded\n");
 	return 0;
 }
 
 static void mpu6050_exit(void)
 {
+	i2c_del_driver(&mpu6050_i2c_driver);
+	pr_info("mpu6050: i2c driver deleted\n");
+
 	pr_info("mpu6050: module exited\n");
 }
 

--- a/mpu6050/mpu6050.c
+++ b/mpu6050/mpu6050.c
@@ -20,6 +20,10 @@ static struct mpu6050_data g_mpu6050_data;
 static int mpu6050_read_data(void)
 {
 	int temp;
+	int value;
+	short int_part_fahr;
+	short fract_part_fahr;
+
 	struct i2c_client *drv_client = g_mpu6050_data.drv_client;
 
 	if (drv_client == 0)

--- a/mpu6050/mpu6050.c
+++ b/mpu6050/mpu6050.c
@@ -4,9 +4,10 @@
 #include <linux/err.h>
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
-
 #include "mpu6050-regs.h"
 
+#define DIV	340
+#define MULTIPL	1000
 
 struct mpu6050_data {
 	struct i2c_client *drv_client;

--- a/mpu6050/mpu6050.c
+++ b/mpu6050/mpu6050.c
@@ -185,13 +185,13 @@ static ssize_t temp_show(struct class *class,
 	return strlen(buf);
 }
 
-CLASS_ATTR(accel_x, 0444, &accel_x_show, NULL);
-CLASS_ATTR(accel_y, 0444, &accel_y_show, NULL);
-CLASS_ATTR(accel_z, 0444, &accel_z_show, NULL);
-CLASS_ATTR(gyro_x, 0444, &gyro_x_show, NULL);
-CLASS_ATTR(gyro_y, 0444, &gyro_y_show, NULL);
-CLASS_ATTR(gyro_z, 0444, &gyro_z_show, NULL);
-CLASS_ATTR(temperature, 0444, &temp_show, NULL);
+static struct class_attribute class_attr_accel_x = __ATTR(accel_x, 0444, &accel_x_show, NULL);
+static struct class_attribute class_attr_accel_y = __ATTR(accel_y, 0444, &accel_y_show, NULL);
+static struct class_attribute class_attr_accel_z = __ATTR(accel_z, 0444, &accel_z_show, NULL);
+static struct class_attribute class_attr_gyro_x = __ATTR(gyro_x, 0444, &gyro_x_show, NULL);
+static struct class_attribute class_attr_gyro_y = __ATTR(gyro_y, 0444, &gyro_y_show, NULL);
+static struct class_attribute class_attr_gyro_z = __ATTR(gyro_z, 0444, &gyro_z_show, NULL);
+static struct class_attribute class_attr_temperature = __ATTR(temperature, 0444, &temp_show, NULL);
 
 static struct class *attr_class;
 

--- a/mpu6050_scripts/get_temperature.sh
+++ b/mpu6050_scripts/get_temperature.sh
@@ -6,3 +6,10 @@ else
 	echo "Error occurred!"
 	exit
 fi
+
+while :
+do
+	HIGH=$(i2cget -y 0 0x68 0x41)
+	LOW=$(i2cget -y 0 0x68 0x42)
+	sleep 1
+done

--- a/mpu6050_scripts/get_temperature.sh
+++ b/mpu6050_scripts/get_temperature.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if i2cset -y 0 0x68 0x6b 0 ; then
+	sleep 0.2
+else
+	echo "Error occurred!"
+	exit
+fi

--- a/mpu6050_scripts/get_temperature.sh
+++ b/mpu6050_scripts/get_temperature.sh
@@ -11,5 +11,13 @@ while :
 do
 	HIGH=$(i2cget -y 0 0x68 0x41)
 	LOW=$(i2cget -y 0 0x68 0x42)
+
+	SIGN=$(( (HIGH & 0x80) >> 7 ))
+	TEMP=$(( (HIGH << 8) + LOW ))
+
+	if [ $SIGN -eq 1 ] ; then
+		TEMP=$(( -(0x10000 - TEMP) ))
+	fi
+
 	sleep 1
 done

--- a/mpu6050_scripts/get_temperature.sh
+++ b/mpu6050_scripts/get_temperature.sh
@@ -19,5 +19,10 @@ do
 		TEMP=$(( -(0x10000 - TEMP) ))
 	fi
 
+	printf "Celsius: "
+	bc -l <<< "scale=3; $TEMP/340 + 36.53"
+	printf "Fahrenheit: "
+	bc -l <<< "scale=3; ($TEMP/340 + 36.53) * 1.8 + 32"
+	echo "------------------"
 	sleep 1
 done


### PR DESCRIPTION
# Summary
This is my implementation of bash script for output of TEMP_OUT registers value of MPU6050 to user space with i2c-tools. Processed values printed in Celsius and Fahrenheit representation.

Also given kernel module for MPU6050 was modified. Added temperature measuring in Fahrenheits and Celsius with precision of 0.001

@yekovalyov please, review my work.